### PR TITLE
Made CLI more terse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           submodules: true
       - name: Install Rust
-        uses: actions-rs/toolchain@v2
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Use stable rust toolchain
+        run: rustup default stable
       - name: Build
         run: cargo build
       - name: Check Formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,24 +15,17 @@ jobs:
       fail-fast: false
     steps:
       - name: Clone repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v2
         with:
           toolchain: stable
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Check Formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --check
+        run: cargo fmt --check
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -- --nocapture
+        run: cargo test -- --nocapture
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: Install Rust
         uses: actions-rs/toolchain@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v2
         with:
           toolchain: stable
       - name: Publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{secrets.CRATES_AUTH_TOKEN}}
+        run: cargo publish --token ${{secrets.CRATES_AUTH_TOKEN}}
   github-release-binaries:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -32,16 +29,13 @@ jobs:
       fail-fast: false
     steps:
       - name: Clone repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v2
         with:
           toolchain: stable
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: cargo build --release
       - name: Package Binary
         if: matrix.os == 'windows-latest'
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v2
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,8 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Use stable rust toolchain
+        run: rustup default stable
       - name: Publish
         run: cargo publish --token ${{secrets.CRATES_AUTH_TOKEN}}
   github-release-binaries:
@@ -30,10 +28,8 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
-      - name: Install Rust
-        uses: actions-rs/toolchain@v2
-        with:
-          toolchain: stable
+      - name: Use stable rust toolchain
+        run: rustup default stable
       - name: Build
         run: cargo build --release
       - name: Package Binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ anyhow = "1.0.81"
 clap = { version = "4.5.4", features = ["derive"] }
 csv = "1.3.0"
 serde = { version = "1.0.197", features = ["derive"] }
-tree-sitter = "0.22.2"
-tree-sitter-tlaplus = "1.2.1"
+tree-sitter = "0.22.5"
+tree-sitter-tlaplus = "1.2.7"
 
 [dev-dependencies]
 glob = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 csv = "1.3.0"
 serde = { version = "1.0.197", features = ["derive"] }
 tree-sitter = "0.22.5"
-tree-sitter-tlaplus = "1.2.7"
+tree-sitter-tlaplus = "1.2.8"
 
 [dev-dependencies]
 glob = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "tlauc"
 description = "Rewrites TLA⁺ specs to use Unicode symbols instead of ASCII, and vice-versa"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["Andrew Helwer <2n8rn1w1f@mozmail.com>"]
 repository = "https://github.com/tlaplus-community/tlauc"
 license = "MIT"
 readme = "README.md"
 keywords = ["tla+", "tlaplus", "pluscal", "unicode"]
 categories = ["command-line-utilities", "text-editors"]
-edition = "2018"
+edition = "2021"
 exclude = ["tests", ".github", ".gitignore", ".gitmodules"]
 
 [dependencies]
-anyhow = "1.0.75"
-clap = { version = "4.0.32", features = ["derive"] }
+anyhow = "1.0.81"
+clap = { version = "4.5.4", features = ["derive"] }
 csv = "1.3.0"
-serde = { version = "1.0.192", features = ["derive"] }
-tree-sitter = "0.20.10"
-tree-sitter-tlaplus = "1.0.6"
+serde = { version = "1.0.197", features = ["derive"] }
+tree-sitter = "0.22.2"
+tree-sitter-tlaplus = "1.2.1"
 
 [dev-dependencies]
-glob = "0.3.0"
-rayon = "1.6.1"
+glob = "0.3.1"
+rayon = "1.10.0"
 

--- a/README.md
+++ b/README.md
@@ -37,17 +37,20 @@ To get the command line tool, either download it directly from [a release](https
 1. Run `cargo install tlauc`
 1. Ensure the [cargo installation directory](https://doc.rust-lang.org/cargo/commands/cargo-install.html#description) is on your path
 
-From the command line, convert a TLA⁺ file from ASCII to Unicode as follows:
+From the command line, convert a TLA⁺ file from ASCII to Unicode in place as follows:
 ```sh
-tlauc unicode --input Ascii.tla --output Unicode.tla
+tlauc Ascii.tla
 ```
-Convert from Unicode to ASCII:
+Convert from Unicode to ASCII in place:
 ```sh
-tlauc ascii --input Unicode.tla --output Ascii.tla
+tlauc Unicode.tla --ascii
 ```
-By default, the program will fail if a file exists at the output location; override this behavior with the `--overwrite` flag.
-There are also several safety checks performed during the translation process, like that the input spec parses correctly and that the output spec has the same parse tree as the input spec.
-You can override these safety checks with the `-f` or `--force` flag, which also sets the `--overwrite` flag.
+To output to a separate file instead of overwriting the input, use the `--output` or `-o` parameter with a filepath.
+There are several safety checks performed during the translation process, like that the input spec parses correctly and that the output spec has the same parse tree as the input spec.
+You can override these safety checks with the `--force` or `-f` flag.
+
+If parse errors exist their locations will be output as a best-effort list of line numbers.
+Unfortunately tree-sitter does not expose more advanced parse error reporting at this time.
 
 To consume the library, add [the tlauc package](https://crates.io/crates/tlauc) as a dependency of your project then use it as follows:
 ```rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub enum TlaError {
 pub fn rewrite(input: &str, mode: &Mode, force: bool) -> Result<String, TlaError> {
     let mut parser = Parser::new();
     parser
-        .set_language(tree_sitter_tlaplus::language())
+        .set_language(&tree_sitter_tlaplus::language())
         .expect("Error loading TLA⁺ grammar");
     let mut cursor = QueryCursor::new();
 
@@ -313,7 +313,7 @@ struct InfixOp {
 impl JList {
     fn query() -> Query {
         Query::new(
-            tree_sitter_tlaplus::language(),
+            &tree_sitter_tlaplus::language(),
             "[(conj_list) (disj_list)] @jlist",
         )
         .unwrap()
@@ -321,7 +321,7 @@ impl JList {
 
     fn terminating_infix_op_query() -> Query {
         Query::new(
-            tree_sitter_tlaplus::language(),
+            &tree_sitter_tlaplus::language(),
             "(bound_infix_op lhs: [(conj_list) (disj_list)]) @capture",
         )
         .unwrap()
@@ -404,7 +404,7 @@ fn mark_symbols(tree: &Tree, cursor: &mut QueryCursor, tla_lines: &mut [TlaLine]
         .map(|s| s.source_query(mode))
         .collect::<Vec<String>>()
         .join("");
-    let query = Query::new(tree_sitter_tlaplus::language(), queries).unwrap();
+    let query = Query::new(&tree_sitter_tlaplus::language(), queries).unwrap();
 
     for capture in cursor.matches(&query, tree.root_node(), "".as_bytes()) {
         let capture = capture.captures[0];
@@ -533,7 +533,7 @@ mod tests {
     fn check_ascii_replaced(text: &str) {
         let mut parser = Parser::new();
         parser
-            .set_language(tree_sitter_tlaplus::language())
+            .set_language(&tree_sitter_tlaplus::language())
             .unwrap();
         let tree = parser.parse(&text, None).unwrap();
         assert!(!tree.root_node().has_error());
@@ -543,7 +543,7 @@ mod tests {
             .map(|s| s.ascii_query())
             .collect::<Vec<String>>()
             .join("");
-        let query = Query::new(tree_sitter_tlaplus::language(), &queries).unwrap();
+        let query = Query::new(&tree_sitter_tlaplus::language(), &queries).unwrap();
         assert_eq!(
             0,
             cursor

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,22 @@
 use anyhow::{anyhow, Context, Result};
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{PathBuf, Path};
 use tlauc::{rewrite, Mode, TlaError};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    #[command(subcommand)]
-    action: Action,
-}
-
-#[derive(Subcommand)]
-enum Action {
-    #[command(about = "Convert symbols in a TLA⁺ file from ASCII to Unicode")]
-    Unicode(Config),
-
-    #[command(about = "Convert symbols in a TLA⁺ file from Unicode to ASCII")]
-    Ascii(Config),
-}
-
-#[derive(Parser)]
-struct Config {
-    #[arg(short, long, help = "Path to TLA⁺ file to read as input")]
-    input: String,
+    #[arg(help = "Path to TLA⁺ file to convert")]
+    input: PathBuf,
 
     #[arg(
         short,
         long,
-        help = "Path to file to use as output; will fail if file already exists unless using --overwrite"
+        help = "Optional path to output; will overwrite input file by default"
     )]
-    output: String,
+    output: Option<PathBuf>,
 
     #[arg(
         short,
@@ -44,37 +29,36 @@ struct Config {
     #[arg(
         long,
         default_value_t = false,
-        help = "Whether to overwrite any file existing at the output path; also set by --force"
+        help = "Convert the TLA⁺ file to ASCII instead of Unicode"
     )]
-    overwrite: bool,
+    ascii: bool,
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    match args.action {
-        Action::Unicode(config) => convert(&config, Mode::AsciiToUnicode),
-        Action::Ascii(config) => convert(&config, Mode::UnicodeToAscii),
-    }
+    let output_path = if let Some(output_path) = args.output {output_path} else {args.input.clone()};
+    convert(
+        args.input.as_path(),
+        output_path.as_path(),
+        if args.ascii {Mode::UnicodeToAscii} else {Mode::AsciiToUnicode},
+        args.force
+    )
 }
 
-fn convert(config: &Config, mode: Mode) -> Result<()> {
+fn convert(input_path: &Path, output_path: &Path, mode: Mode, force: bool) -> Result<()> {
     let mut input = String::new();
     {
-        let mut input_file = File::open(&config.input)
-            .context(format!("Failed to open input file [{}]", &config.input))?;
+        let mut input_file = File::open(input_path)
+            .context(format!("Failed to open input file [{:?}]", input_path))?;
         input_file
             .read_to_string(&mut input)
-            .context(format!("Failed to read input file [{}]", &config.input))?;
+            .context(format!("Failed to read input file [{:?}]", input_path))?;
     }
 
-    if Path::new(&config.output).exists() && !(config.overwrite || config.force) {
-        return Err(anyhow!("File already exists at output file location [{}]; use --overwrite flag to overwrite it", &config.output));
-    }
-
-    let mut output_file = File::create(&config.output)?;
-    match rewrite(&input, &mode, config.force) {
+    let mut output_file = File::create(output_path)?;
+    match rewrite(&input, &mode, force) {
         Ok(output) => {
-            output_file.write_all(output.as_bytes()).context(format!("Failed to write to output file [{}]", &config.output))?;
+            output_file.write_all(output.as_bytes()).context(format!("Failed to write to output file [{:?}]", output_path))?;
             Ok(())
         },
         Err(TlaError::InputFileParseError { error_lines, .. }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use tlauc::{rewrite, Mode, TlaError};
 
 #[derive(Parser)]
@@ -36,12 +36,20 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let output_path = if let Some(output_path) = args.output {output_path} else {args.input.clone()};
+    let output_path = if let Some(output_path) = args.output {
+        output_path
+    } else {
+        args.input.clone()
+    };
     convert(
         args.input.as_path(),
         output_path.as_path(),
-        if args.ascii {Mode::UnicodeToAscii} else {Mode::AsciiToUnicode},
-        args.force
+        if args.ascii {
+            Mode::UnicodeToAscii
+        } else {
+            Mode::AsciiToUnicode
+        },
+        args.force,
     )
 }
 


### PR DESCRIPTION
Converts file to unicode in-place by default, with an extra option to output to a different file. No warnings for overwriting files.

Closes #9