### PR TITLE
Added translation `--skip` parameter to CLI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,29 @@ Convert from Unicode to ASCII in place:
 ```sh
 tlauc Unicode.tla --ascii
 ```
-To output to a separate file instead of overwriting the input, use the `--output` or `-o` parameter with a filepath.
+To output to a separate file instead of overwriting the input, use the `--output` or `-o` parameter with a filepath:
+```sh
+tlauc Input.tla --output Output.tla
+```
+If you want to avoid translating particular symbols, specify them with the `--skip` parameter; this will skip translation in both directions for all aliases of the given symbol:
+```sh
+tlauc Input.tla --skip "<=" --skip "\\/"
+```
+There are also handy keywords to skip groups of symbols; the `numsets` keyword will avoid translating `Nat`, `Int`, and `Real` to `ℕ`, `ℤ`, and `ℝ`:
+```sh
+tlauc Input.tla --skip "numsets"
+```
+This is useful as [SANY does not yet define](https://github.com/tlaplus/tlaplus/issues/1020) these Unicode number sets in the standard modules.
+If you want the Unicode number sets to be successfully parsed by SANY, you'll have to manually add a definition like this near the top of your module:
+```tla
+LOCAL ℕ == Nat
+```
+The `contractions` keyword is also supported, which avoids translating Unicode symbols that are simple contractions of their constituent ASCII symbols: `∷`, `‥`, `…`, `≔`, `⩴`, `‖`, `‼`, and `⁇`.
+Skip keywords can be used alongside specific skip literals, as in:
+```sh
+tlauc Input.tla --skip "contractions" --skip "/\\" --skip "\\/" --skip "numsets"
+```
+
 There are several safety checks performed during the translation process, like that the input spec parses correctly and that the output spec has the same parse tree as the input spec.
 You can override these safety checks with the `--force` or `-f` flag.
 
@@ -71,7 +93,7 @@ IsTotallyOrdered(S) ==
     /\ Rotal(S)
 THEOREM RealsTotallyOrdered == IsTotallyOrdered(Real)
 ===="#;
-    println!("{}", rewrite(input, &Mode::AsciiToUnicode, false).unwrap());
+    println!("{}", rewrite(input, &Mode::AsciiToUnicode, false, |_| true).unwrap());
 }
 ```
 which will output:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use tlauc::{rewrite, Mode, TlaError};
+use tlauc::{rewrite, Mode, SymbolMapping, TlaError};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -32,6 +33,16 @@ struct Args {
         help = "Convert the TLA⁺ file to ASCII instead of Unicode"
     )]
     ascii: bool,
+
+    #[arg(
+        long,
+        help = "Symbol to skip translating. All symbol aliases are also skipped. Can define multiple. Two formats are recognized:
+ 1. A literal alias of the symbol to skip, like \"\\leq\" or \"∀\".
+ 2. Supported keywords as shorthand for groups of symbols:
+   - \"numsets\" refers to ℕ, ℤ, and ℝ
+   - \"contractions\" refers to ∷, ‥, …, ≔, ⩴, ‖, ‼, and ⁇"
+    )]
+    skip: Vec<String>,
 }
 
 fn main() -> Result<()> {
@@ -50,10 +61,17 @@ fn main() -> Result<()> {
             Mode::AsciiToUnicode
         },
         args.force,
+        args.skip,
     )
 }
 
-fn convert(input_path: &Path, output_path: &Path, mode: Mode, force: bool) -> Result<()> {
+fn convert(
+    input_path: &Path,
+    output_path: &Path,
+    mode: Mode,
+    force: bool,
+    skip: Vec<String>,
+) -> Result<()> {
     let mut input = String::new();
     {
         let mut input_file = File::open(input_path)
@@ -63,7 +81,7 @@ fn convert(input_path: &Path, output_path: &Path, mode: Mode, force: bool) -> Re
             .context(format!("Failed to read input file [{:?}]", input_path))?;
     }
 
-    match rewrite(&input, &mode, force) {
+    match rewrite(&input, &mode, force, symbol_filter(skip_symbols(skip))) {
         Ok(output) => {
             let mut output_file = File::create(output_path)?;
             output_file.write_all(output.as_bytes()).context(format!("Failed to write to output file [{:?}]", output_path))?;
@@ -84,9 +102,263 @@ fn convert(input_path: &Path, output_path: &Path, mode: Mode, force: bool) -> Re
     }
 }
 
+const NUMSETS: [&'static str; 6] = ["Nat", "ℕ", "Int", "ℤ", "Real", "ℝ"];
+
+const CONTRACTIONS: [&'static str; 8] = ["∷", "‥", "…", "≔", "⩴", "‖", "‼", "⁇"];
+
+fn skip_symbols(skip: Vec<String>) -> HashSet<String> {
+    skip.iter()
+        .map(|name| match name.as_str() {
+            "numsets" => NUMSETS.into_iter().collect(),
+            "contractions" => CONTRACTIONS.into_iter().collect(),
+            val => vec![val],
+        })
+        .flatten()
+        .map(|s| s.to_owned())
+        .collect()
+}
+
+fn symbol_filter(skip_symbol: HashSet<String>) -> impl Fn(&SymbolMapping) -> bool {
+    move |symbol| {
+        !&symbol
+            .ascii
+            .iter()
+            .any(|literal| skip_symbol.contains(literal))
+            && !skip_symbol.contains(&symbol.unicode)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::iter::once;
+    use tlauc::get_unicode_mappings;
+
     use super::*;
+
+    #[test]
+    fn test_skip_keyword_parsing() {
+        assert_eq!(
+            skip_symbols(vec!["numsets".to_owned()]),
+            NUMSETS.into_iter().map(|val| val.to_owned()).collect()
+        );
+        assert_eq!(
+            skip_symbols(vec!["contractions".to_owned()]),
+            CONTRACTIONS.into_iter().map(|val| val.to_owned()).collect()
+        );
+        assert_eq!(
+            skip_symbols(vec!["numsets".to_owned(), "contractions".to_owned()]),
+            CONTRACTIONS
+                .into_iter()
+                .chain(NUMSETS)
+                .map(|val| val.to_owned())
+                .collect()
+        );
+        assert_eq!(
+            skip_symbols(vec![
+                "<=".to_owned(),
+                "numsets".to_owned(),
+                "\\/".to_owned()
+            ]),
+            NUMSETS
+                .into_iter()
+                .chain(once("<="))
+                .chain(once("\\/"))
+                .map(|val| val.to_owned())
+                .collect()
+        );
+        assert_eq!(
+            skip_symbols(vec![
+                "contractions".to_owned(),
+                "<=".to_owned(),
+                "numsets".to_owned(),
+                "\\/".to_owned()
+            ]),
+            CONTRACTIONS
+                .into_iter()
+                .chain(NUMSETS)
+                .chain(once("<="))
+                .chain(once("\\/"))
+                .map(|val| val.to_owned())
+                .collect()
+        );
+    }
+
+    #[test]
+    fn test_skip_filters() {
+        let mappings = get_unicode_mappings();
+        let filter = symbol_filter(skip_symbols(vec!["numsets".to_owned()]));
+        assert!(!filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("nat_number_set"))
+                .unwrap()
+        ));
+        assert!(!filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("int_number_set"))
+                .unwrap()
+        ));
+        assert!(!filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("real_number_set"))
+                .unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("label_as")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("dots_2")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("dots_3")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("assign")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("bnf_rule")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("vertvert")).unwrap()
+        ));
+        assert!(filter(mappings.iter().find(|s| s.name.eq("excl")).unwrap()));
+        assert!(filter(mappings.iter().find(|s| s.name.eq("qq")).unwrap()));
+        let filter = symbol_filter(skip_symbols(vec!["contractions".to_owned()]));
+        assert!(filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("nat_number_set"))
+                .unwrap()
+        ));
+        assert!(filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("int_number_set"))
+                .unwrap()
+        ));
+        assert!(filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("real_number_set"))
+                .unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("label_as")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("dots_2")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("dots_3")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("assign")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("bnf_rule")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("vertvert")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("excl")).unwrap()
+        ));
+        assert!(!filter(mappings.iter().find(|s| s.name.eq("qq")).unwrap()));
+        let filter = symbol_filter(skip_symbols(vec![
+            "numsets".to_owned(),
+            "contractions".to_owned(),
+        ]));
+        assert!(!filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("nat_number_set"))
+                .unwrap()
+        ));
+        assert!(!filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("int_number_set"))
+                .unwrap()
+        ));
+        assert!(!filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("real_number_set"))
+                .unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("label_as")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("dots_2")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("dots_3")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("assign")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("bnf_rule")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("vertvert")).unwrap()
+        ));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("excl")).unwrap()
+        ));
+        assert!(!filter(mappings.iter().find(|s| s.name.eq("qq")).unwrap()));
+        let filter = symbol_filter(skip_symbols(vec![
+            "<=".to_owned(),
+            "/\\".to_owned(),
+            "\\/".to_owned(),
+        ]));
+        assert!(!filter(mappings.iter().find(|s| s.name.eq("leq")).unwrap()));
+        assert!(!filter(
+            mappings.iter().find(|s| s.name.eq("land")).unwrap()
+        ));
+        assert!(!filter(mappings.iter().find(|s| s.name.eq("lor")).unwrap()));
+        assert!(filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("nat_number_set"))
+                .unwrap()
+        ));
+        assert!(filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("int_number_set"))
+                .unwrap()
+        ));
+        assert!(filter(
+            mappings
+                .iter()
+                .find(|s| s.name.eq("real_number_set"))
+                .unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("label_as")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("dots_2")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("dots_3")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("assign")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("bnf_rule")).unwrap()
+        ));
+        assert!(filter(
+            mappings.iter().find(|s| s.name.eq("vertvert")).unwrap()
+        ));
+        assert!(filter(mappings.iter().find(|s| s.name.eq("excl")).unwrap()));
+        assert!(filter(mappings.iter().find(|s| s.name.eq("qq")).unwrap()));
+    }
 
     #[test]
     // https://github.com/tlaplus-community/tlauc/issues/14
@@ -102,6 +374,7 @@ mod tests {
             output_path.as_path(),
             tlauc::Mode::AsciiToUnicode,
             false,
+            vec![],
         );
         assert!(result.is_err());
         let actual = std::fs::read_to_string(&output_path).unwrap();
@@ -120,6 +393,7 @@ mod tests {
             output_path.as_path(),
             tlauc::Mode::AsciiToUnicode,
             false,
+            vec![],
         );
         assert!(result.is_err());
     }

--- a/tests/corpus_tests.rs
+++ b/tests/corpus_tests.rs
@@ -53,9 +53,14 @@ mod corpus_tests {
                     .expect(&format!("Failed to read input file [{:?}]", path));
             }
 
-            let intermediate =
-                unwrap_conversion(rewrite(&input, &Mode::AsciiToUnicode, false), path);
-            unwrap_conversion(rewrite(&intermediate, &Mode::UnicodeToAscii, false), path);
+            let intermediate = unwrap_conversion(
+                rewrite(&input, &Mode::AsciiToUnicode, false, |_| true),
+                path,
+            );
+            unwrap_conversion(
+                rewrite(&intermediate, &Mode::UnicodeToAscii, false, |_| true),
+                path,
+            );
         });
 
         println!("Corpus tests took {} seconds", start.elapsed().as_secs());


### PR DESCRIPTION
Recognizes `numsets` and `contractions` keywords

Closes #17 and #22